### PR TITLE
Added word break for long words in <code>

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -133,6 +133,11 @@ td, th {
   word-break: break-word;
 }
 
+code {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 thead {
   font-weight: normal;
   font-family: "8bitOperatorPlus-Bold", monospace;


### PR DESCRIPTION
![alepos](https://m.media-amazon.com/images/I/710AwdWnBLL._AC_UF894,1000_QL80_.jpg)

Did it differently, by making another specific break-word for <code>, and also used your advice to not pull request a messy history of commits.

Btw read on mdn web docs that break-word works as last resort, when one word can't nicely fit into one line.