### PR TITLE
Add information about Registry hooking to the Hooks page

### DIFF
--- a/app/wiki/creating-a-mod/page.mdx
+++ b/app/wiki/creating-a-mod/page.mdx
@@ -357,23 +357,22 @@ This folder contains everything associated with maps and the world in Kristal. T
 
 #### Script IDs
 
-Scripts load into a part of Kristal known as the `Registry`. When that happens, they are assigned an `id` you'll need to know to access them later.
+Scripts load into a part of Kristal known as the `Registry`. When that happens, they are assigned an ID you'll need to know to access them later.
 
-The `id` assigned to a script is determined in two simple steps - it's very important to know them!
+The ID assigned to a script is determined in two simple steps - it's very important to know them!
 
-**Step 1.** The engine checks whether the script ID was defined explicitly as the second argument to `Class()` (in most scripts). If it is, that's the script's id.
+**Step 1.** The engine checks whether the script ID was defined explicitly as the second argument to `Class()` (in most scripts). If it is, that's the script's ID.
 
 **Step 2.** If the script doesn't have an explicit ID, the engine uses it's file path. This starts from the **subfolder of the script type**, not the `scripts` folder.
-For example, an item at `scripts/data/items/light/pencil.lua` would be assigned the id `light/pencil`.
+For example, an item at `scripts/data/items/light/pencil.lua` would be assigned the ID `light/pencil`.
 
 These are also **case-sensitive** - `Light/Pencil` and `light/pencil` are considered completely seperate IDs!
 
-#### Replacing Engine Scripts
+#### Changing Engine Scripts
 
-Just like Assets, the engine has some scripts that are not visible from your mod folder. The only applies to `data` scripts.
+The engine has some `data/` scripts that appear ingame but are not visible from your mod folder. If you want to modify them, you'll need to use hooks.
 
-The same procedure works for replacing data scripts as it does assets - look through the `data` folder of the [source code](https://github.com/KristalTeam/Kristal/tree/main), and create a file at the **same path** as the one in the engine to **replace** it.
-
+Hooks are a more advanced feature of the engine that aren't recommended if you're starting out. But when you need them, you can read about them [here](/wiki/hooks).
 </details>
 
 ---

--- a/app/wiki/hooks/page.mdx
+++ b/app/wiki/hooks/page.mdx
@@ -42,7 +42,9 @@ With that out of the way, let's make some hooks!
 
 ---
 
-In Kristal, all hook files should be placed into `scripts/hooks/`. (Well, mostly. There's a small exception to this explained [later](#registry-hooks).)
+In Kristal, all hook files should be placed into `scripts/hooks/`. 
+
+*(Well, mostly. If you want to hook anything from the engine's `data/` folder, the steps are slightly different. This is explained [later](#registry-hooks).)*
 
 Each hook targets exactly one class at a time with the `Utils.hookScript(target)` function. To create a new hook, we start by creating a file in the hooks folder named after the target.
 

--- a/app/wiki/hooks/page.mdx
+++ b/app/wiki/hooks/page.mdx
@@ -42,9 +42,9 @@ With that out of the way, let's make some hooks!
 
 ---
 
-In Kristal, hooks are performed in files located in `scripts/hooks/` with the `Utils.hookScript(target)` function.
+In Kristal, all hook files should be placed into `scripts/hooks/`. (Well, mostly. There's a small exception to this explained [later](#registry-hooks).)
 
-Each hook targets exactly one class at a time, so to create a new hook, we start by creating a file named after the target.
+Each hook targets exactly one class at a time with the `Utils.hookScript(target)` function. To create a new hook, we start by creating a file in the hooks folder named after the target.
 
 Say you wanted to hook the `EnemyBattler` class. You would create `EnemyBattler.lua` inside `scripts/hooks/`. Then, you would insert the following:
 
@@ -280,6 +280,39 @@ end
 </Box>
 
 <Box>
+## Registry Hooks
+
+Remember when we said all hooks go into `scripts/hooks/`? Well, that was actually a **Lie**.
+
+As the section title very likely gave away, content managed by the Registry has to be hooked differently. That's any file in the `data/` folder of the engine source e.g. actors, party members, items.
+
+Hook files for the registry must go into their **respective data sub-folders** inside of `scripts/data/`, rather than the hooks folder.
+
+Let's run through hooking the Dark (or Darker) Candy item as an example.
+
+---
+Dark Candy is an item, so the folder you want to be in is `scripts/data/items`. Inside, create a new file named **the same as the original** - in this case, that's `dark_candy.lua`.
+
+The contents of the file are nearly the same as any other hook. Here's a basic one that changes the dark candy to heal 400 HP:
+
+```lua
+local item, super = Utils.hookScript("dark_candy")
+
+function item:init()
+    super.init(self)
+
+    self.heal_amount = 400
+end
+
+return item
+```
+
+The only difference here is that we're now using a string with the ID we want to hook in `Utils.hookScript()`. (See how the engine determines Script IDs [here](/wiki/creating-a-mod#script-ids).)
+
+That's our registry hook set up and good to go!
+</Box>
+
+<Box>
 ## Hook Annotations
 
 With hooks, you are able to change function parameters or add new functions to classes.
@@ -295,7 +328,7 @@ We don't want that to happen! We need to annotate any changes in our hooks to cl
 The main thing you can always do is add the following annotation line at the very top of your hook file, above even the hookScript call:
 
 ```lua
----@class ClassName : ClassName
+---@class ClassName
 ```
 
 Change `ClassName` to the name of the class you're hooking.


### PR DESCRIPTION
Since registry hooks operate slightly differently to regular hooks, this adds a small section to the hooks page that explains the differences with them. 

The creating a mod page also points to hooks for this purpose now (as For Some Reason I had previously suggested replacing them outright??? 😭 )