### PR TITLE
Recommend blob-less Git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 First, run the development server:
 
-```bash
+```sh
 npm run dev
 # or
 yarn dev

--- a/app/wiki/downloading/page.mdx
+++ b/app/wiki/downloading/page.mdx
@@ -78,7 +78,7 @@ The instructions below should work on all platforms, but they have only mainly b
 3. Navigate to the folder where you want to download Kristal.
 4. Clone the repository. That can be done with the following command:
 
-```bash
+```sh
 git clone https://github.com/KristalTeam/Kristal
 ```
 

--- a/app/wiki/downloading/page.mdx
+++ b/app/wiki/downloading/page.mdx
@@ -79,7 +79,7 @@ The instructions below should work on all platforms, but they have only mainly b
 4. Clone the repository. That can be done with the following command:
 
 ```sh
-git clone https://github.com/KristalTeam/Kristal
+git clone --filter=blob:none https://github.com/KristalTeam/Kristal
 ```
 
 This will download the source code to the folder you are in,


### PR DESCRIPTION
https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone

Additionally, this PR changes `bash` Markdown code-blocks to `sh`, which is shorter and more neutral
