### PR TITLE
mention `PATH` env-var in download/run guide

### DIFF
--- a/app/wiki/downloading/page.mdx
+++ b/app/wiki/downloading/page.mdx
@@ -132,11 +132,13 @@ This will run Kristal as well, but it is less convenient.
 
 If you're doing project development, a useful resource is **the output console**. To open it, use `lovec.exe` rather than `love.exe`.
 
+You can also append the directory where `love` is in to the `PATH` [environment variable](/wiki/glossary#environment-variable).
+
 ---
 
 ### Running Kristal's sources on other platforms
 
-On other platforms, you can easily just run `love path/to/kristal` in a terminal once it's installed.
+On other platforms, you can easily just run `love path/to/kristal` in a terminal once it's installed. This is typically the case if you installed it using a package manager.
 
 
 </Box>

--- a/app/wiki/glossary/page.mdx
+++ b/app/wiki/glossary/page.mdx
@@ -33,6 +33,14 @@ In the cases it DOES matter, you most likely know the difference anyways.</small
 
 ---
 
+### Environment variable
+
+AKA "`env` vars", are variables whose values can be read from anywhere.
+
+[See](https://en.wikipedia.org/wiki/Environment_variable)
+
+---
+
 ### Repository
 
 Most of the time, we're referring to a "Git repository", which is a way for developers to manage and share their code.


### PR DESCRIPTION
This improves the "Downloading" guide so that users are aware of `PATH`, for convenience when running `love`. It also adds an env-var entry to the glossary
