### PR TITLE
Add more debug keybinds and slightly polish Debugging page

### DIFF
--- a/app/wiki/debugging/page.mdx
+++ b/app/wiki/debugging/page.mdx
@@ -28,38 +28,37 @@ Go to Kristal's options menu and head over to the Keyboard Controls. Scroll down
 
 <>![image](/wiki/debug_controls.png)</>
 
-These are the default binds for the other debug tools we'll be using. 
-
-Be mindful of the `` ` `` (backtick) some of these binds use. It looks close to an `` ' `` (apostrophe), even if it isn't. **Make sure not to mix them up!**
+These are the keybinds for the debug tools we'll be using. Beware the backtick (`` ` ``) key in particular, as it can easily be mistaken for the apostrophe (`` ' ``). **Make sure not to mix them up!**
 </Box>
 
 <Box>
 ## Debug Hotkeys
 
-Debug Hotkeys are fairly straightforward. Press some keys, and something happens.
-That something is generally going to help your testing go faster, like giving full heals, TP restoration, or, quite literally, speeding up the game.
+Debug Hotkeys are a quick and simple tool we can use to mess with the game state or toggle certain debugging features. 
 
-Here's the full list of the debug keys and what they do:
+To use them, all we need to do is press some keys, and then something will happen.
+
+These hotkeys are as follows:
 
 - `Ctrl+R` quicksaves the game and then reloads your project. You'll load back to whatever world/map and state you were in previously.
 - `Ctrl+Shift+R` reloads the game without quicksaving. You'll load in from when you last saved.
 - `Ctrl+Alt+R` reloads the game from a new file.
+- `Ctrl+Alt+Shift+R` hard resets the engine. Use this if any behaviour seems to unexpectedly persist between reloads.
 - `Ctrl+M` pauses/resumes the in-game music.
 - `Ctrl+N` toggles noclip.
 - `Ctrl+G` (Fast Forward Keybind) toggles fast-forward.
 - `Ctrl+H` heals your party to full.
 - `Ctrl+K` fully restores TP.
 - `Ctrl+B` kills you instantly.
-
-These two hotkeys only have functionality in battle:
-- `Ctrl+F` ends all active waves.
-- `Ctrl+Y` wins the battle immediately.
-
-These hotkeys use function keys - on some devices, you'll need to use `Ctrl` or `Fn` with these for Kristal to see the input.
+- `Ctrl+I` grants you incvincibility.
+- `Ctrl+F` ends all active waves. (Battle only)
+- `Ctrl+Y` wins the battle immediately. (Battle only)
 - `F2` toggles fast-forward.
 - `F3` opens this website!
 - `F4` enables fullscreen.
 - `F6` enables Debug Rendering.
+
+(On some devices, using the function (`F`) keys may also require pressing `Ctrl` or `Fn` to override other behaviour attached to them.)
 </Box>
 
 <Box>
@@ -67,7 +66,7 @@ These hotkeys use function keys - on some devices, you'll need to use `Ctrl` or 
 
 Here's where the fun part of Debugging begins!
 
-Press `` Ctrl+` `` (or your Debug Menu keybind) to open up the debug menu. It should appear as an overlay on the game window:
+Press the Debug Menu keybind (Defaults to `` Shift+` ``) to open the Debug Menu:
 
 <>![image](/wiki/debug_menu.png)</>
 


### PR DESCRIPTION
Adds the invulnerability and hard reset keybinds to the hotkey list and corrects my very silly mistake of listing `` Ctrl+` `` as the debug menu keybind

While I was adding these i made a few tweaks so that things read and flow slightly better and are a bit more direct

(Also, at some point we can probably split this into one page for each section, which also means we could give the wiki a proper "Debugging" category, my curse of writing Five Pages per Page must be undone...)